### PR TITLE
Adds #start and #mstart matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ end
 * not_eq
 * cont
 * in
+* start
+* mstart
 * gt
 * lt
 * gteq

--- a/lib/ransack_mongo/mongo_adapter.rb
+++ b/lib/ransack_mongo/mongo_adapter.rb
@@ -1,6 +1,6 @@
 module RansackMongo
   class MongoAdapter
-    PREDICATES = %w[eq not_eq cont in gt lt gteq lteq]
+    PREDICATES = %w[eq not_eq cont in start mstart gt lt gteq lteq]
 
     def initialize
       @query = {}
@@ -24,6 +24,20 @@ module RansackMongo
 
     def in_matcher(attr, value)
       @query[attr] = { '$in' => value }
+    end
+
+    def start_matcher(attr, value)
+      @query[attr] = { '$in' => [/^#{value}/] }
+    end
+
+    def mstart_matcher(attr, value)
+      values = value.split(",").map do |current|
+        if (current = current.strip).length > 0
+          /^#{current}/
+        end
+      end.compact
+
+      @query[attr] = { '$in' => values }
     end
 
     def gt_matcher(attr, value)

--- a/spec/ransack_mongo/mongo_adapter_spec.rb
+++ b/spec/ransack_mongo/mongo_adapter_spec.rb
@@ -34,6 +34,34 @@ module RansackMongo
       end
     end
 
+    describe '#start' do
+      it 'returns the matcher' do
+        subject.start_matcher('object_ref', 'Bruno')
+
+        expect(subject.to_query).to eq("object_ref" => { "$in" => [/^Bruno/] })
+      end
+    end
+
+    describe '#mstart' do
+      it 'returns the matcher' do
+        subject.mstart_matcher('name', 'Pablo, Bruno,Dude')
+
+        expect(subject.to_query).to eq("name" => { "$in" => [/^Pablo/, /^Bruno/, /^Dude/] })
+      end
+
+      it 'cleans up the input' do
+        subject.mstart_matcher('name', ',, , ,Pablo,,,,   ,, , , ,')
+
+        expect(subject.to_query).to eq("name" => { "$in" => [/^Pablo/] })
+      end
+
+      it 'accepts single values' do
+        subject.mstart_matcher('name', 'Pablo')
+
+        expect(subject.to_query).to eq("name" => { "$in" => [/^Pablo/] })
+      end
+    end
+
     context 'when combine gt lt gteq and lteq' do
       it 'returns all matchers' do
         subject.gt_matcher('count', '1')


### PR DESCRIPTION
Hey,

This patch adds the `#start` and `#mstart` (multi-start) matchers.
- `#start` generates `{ "$in" => [/^query/] }`
- And given a string like `Pablo, Bruno, Fulano` then `#mstart` generates  `{ "$in" => [/^Pablo/, /^Bruno/, /^Fulano/] }` for [efficient mongo queries](http://docs.mongodb.org/manual/reference/operator/query/regex/#in-expressions).

Cheers :beers: 
